### PR TITLE
Ops manual fix for 2 docker repo routes

### DIFF
--- a/apps/artifactory/artifactory-ha/ops-fixes/99-sample-docker-route.yaml
+++ b/apps/artifactory/artifactory-ha/ops-fixes/99-sample-docker-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ${ARTIFACTORY_NAME}-route-template
+  annotations:
+    description: "Template for artifactory docker routes"
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: ${ARTIFACTORY_NAME}
+    name: "${DOCKER_REPO}"
+  spec:
+    host: "${DOCKER_REPO}.${ARTIFACTORY_DNS_NAME}"
+    port:
+      targetPort: http
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: ${ARTIFACTORY_NAME}
+      weight: 100
+    wildcardPolicy: None
+parameters:
+- description: Artifactory name
+  name: ARTIFACTORY_NAME
+  value: "artifactory"
+  required: true
+- description: Artifactory DNS Suffix
+  name: ARTIFACTORY_DNS_NAME
+  value: "artifacts.developer.gov.bc.ca"
+  required: true
+- description: Docker repository name
+  name: DOCKER_REPO
+  require: true

--- a/apps/artifactory/artifactory-ha/ops-fixes/lab-jk-docker-route.env
+++ b/apps/artifactory/artifactory-ha/ops-fixes/lab-jk-docker-route.env
@@ -1,0 +1,3 @@
+ARTIFACTORY_NAME=artifactory
+ARTIFACTORY_DNS_NAME=artifacts.lab.pathfinder.gov.bc.ca
+DOCKER_REPO=jk-docker-local

--- a/apps/artifactory/artifactory-ha/ops-fixes/prd-bcr-docker-route.env
+++ b/apps/artifactory/artifactory-ha/ops-fixes/prd-bcr-docker-route.env
@@ -1,0 +1,3 @@
+ARTIFACTORY_NAME=artifactory
+ARTIFACTORY_DNS_NAME=artifacts.developer.gov.bc.ca
+DOCKER_REPO=bcr-docker-local

--- a/apps/artifactory/artifactory-ha/ops-fixes/prd-bcrentities-docker-route.env
+++ b/apps/artifactory/artifactory-ha/ops-fixes/prd-bcrentities-docker-route.env
@@ -1,0 +1,3 @@
+ARTIFACTORY_NAME=artifactory
+ARTIFACTORY_DNS_NAME=artifacts.developer.gov.bc.ca
+DOCKER_REPO=prd-bcrentities-docker-local

--- a/apps/artifactory/artifactory-ha/ops-fixes/readme.md
+++ b/apps/artifactory/artifactory-ha/ops-fixes/readme.md
@@ -1,0 +1,16 @@
+# Ops Fixes
+
+## Docker route issue
+
+Operator has a bug that is stopping it from creating the required docker repo routes.  
+
+99-sample-docker-route.yaml - a template to manually create a docker route
+*.env - parameter files for the manually created routes, can track our manual fixes to replace later with automation generated routes.
+
+Sample route fix:
+
+``` bash
+login to cluster
+oc project devops-artifactory
+oc process -f 99-sample-docker-route.yaml --param-file=prd-bcrentities-docker-route.env | oc apply -f -
+```


### PR DESCRIPTION
See Issue: [Artifactory Docker repo fixes](https://github.com/BCDevOps/developer-experience/issues/88)

This PR contains instructions and code for manual fixes applied to add 2 production docker repo routes as a manual workaround.

The repositories with manual routes are:
bcr-docker-local
bcrentities-docker-local
