### PR TITLE
Cailey/requestron/bug fixes

### DIFF
--- a/apps/requestron/lib/closeComment.js
+++ b/apps/requestron/lib/closeComment.js
@@ -1,17 +1,49 @@
 require('probot');
+const axios = require('axios');
 /**
  * Create a comment on close that includes some useful instructions/details
  */
 
+const commentDetails = {
+    'annotation-update': 'You can view your project annotations by running the command `oc describe namespace [namespace-name]`.',
+    'artifactory-repo': 'You can find the custom resource for your repo in the listed tools namespace by running `oc get artifactoryrepos`.' +
+        'For information on the status of the resource, run `oc describe artifactoryrepo [repo-name]`.',
+    'documize-space': 'You should expect to receive an invitation to your Documize space in your email inbox.',
+    'duplicate': 'This task will not be completed because it is a duplicate of another task.',
+    'github-membership': 'The invitation should appear in the relevant user\'s inbox very soon. Please ensure that they\'re checking the correct inbox.' +
+        'The invitation will show up in the inbox of whatever email address is listed as their primary address in their github profile.' +
+        'Please note that this request ONLY provides access to the `bcgov` and/or `bcgov-c` organizations. It does not provide access to Openshift. ' +
+        'If you require that, please open another issue [here](https://github.com/BCDevOps/devops-requests/issues/new?assignees=caggles%2C+ShellyXueHan&labels=openshift-access&template=openshift_user_access_request.md&title=)',
+    'keycloak-realm': 'Please follow the instructions above to use realm-o-matic.',
+    'openshift-access': 'The user in question should receive an invitation to the BCDevOps organization on GitHub. They must accept this invitation before they will be able to access Openshift.' +
+        'The invitation will show up in the inbox of whatever email address is listed as their primary address in their github profile.',
+    'openshift-project-set': 'Assuming this task was approved, you will find your project set by logging into the Openshift console and navigating to the Application Console.' +
+        'There, you will find a list of all projects to which you have access. The technical steward will have admin access and can add new users to the projects as required.'
+};
+const instance = axios.create({
+  baseURL: 'https://api.github.com/',
+  timeout: 10000,
+  headers: {'Authorization': 'token ' + process.env.GITHUB_TOKEN}
+});
+
 module.exports = async function createClosingComment(context) {
     try {
 
-        const closingIssue = context.issue()
-        const issueComment = context.issue({ body: 'This issue has now been closed. It has been completed, ' +
-                'unless a comment indicates otherwise. If you have requested access to either Openshift or the bcgov ' +
-                'github org, remember that you must accept the invitation before access will be available! If you have ' +
-                'additional problems or questions, please feel free to ask on RocketChat on the #devops-howto channel!' })
-        await context.github.issues.createComment(issueComment)
+        const closingIssue = context.issue();
+        const getResponse = await instance.get('repos/' + closingIssue.owner + '/' + closingIssue.repo + '/issues/' + closingIssue.number + '/labels');
+        let commentContent = 'This issue has now been closed. It has been completed, unless a comment indicates otherwise.\n';
+        console.log(getResponse.data.length)
+        for (let i = 0; i < getResponse.data.length; i++) {
+            let label = getResponse.data[i]['name']
+            console.log(label)
+            if (commentDetails[label] != null) {
+                commentContent += '\n' + commentDetails[label] + '\n';
+            }
+        }
+        commentContent += '\nIf you have additional problems or questions, please feel free to ask the community on RocketChat on the `#devops-howto` channel!';
+
+        const issueComment = context.issue({ body: commentContent});
+        await context.github.issues.createComment(issueComment);
         return true;
 
     } catch (err) {

--- a/apps/requestron/lib/estimate.js
+++ b/apps/requestron/lib/estimate.js
@@ -18,7 +18,9 @@ module.exports = async function setEstimate(context) {
         const getResponse = await instance.get('repos/' + openingIssue.owner + '/' + openingIssue.repo + '/issues?labels=ops-controller&status=open');
         const controllerIssueNumber = getResponse.data[0].number;
         const contollerIssueComment = { body: issueUrl };
-        const postResponse = await instance.post('repos/' + openingIssue.owner + '/' + openingIssue.repo + '/issues/' + controllerIssueNumber + '/comments', contollerIssueComment);
+        if (openingIssue.number != controllerIssueNumber){
+            const postResponse = await instance.post('repos/' + openingIssue.owner + '/' + openingIssue.repo + '/issues/' + controllerIssueNumber + '/comments', contollerIssueComment);
+        }
         //console.log(postResponse)
 
         return true;

--- a/apps/requestron/lib/milestone.js
+++ b/apps/requestron/lib/milestone.js
@@ -5,7 +5,7 @@ const axios = require('axios')
 
 const instance = axios.create({
   baseURL: 'https://api.github.com/',
-  timeout: 1000,
+  timeout: 10000,
   headers: {'Authorization': 'token ' + process.env.GITHUB_TOKEN}
 });
 

--- a/apps/requestron/lib/swimlane.js
+++ b/apps/requestron/lib/swimlane.js
@@ -5,7 +5,7 @@ const axios = require('axios')
 
 const instance = axios.create({
   baseURL: 'https://api.zenhub.io/',
-  timeout: 1000,
+  timeout: 10000,
   headers: {'X-Authentication-Token': process.env.ZENHUB_TOKEN}
 });
 


### PR DESCRIPTION
this PR covers 3 things:

1. the closing comments now provide specific content depending on the label(s) applied to the ticket.
2. the ops-controller ticket now no longer counts itself when counting the amount of ops toil we do.
3. the timeout for axios has been increased, hopefully fixing the fact that some tickets don't move into the ops swimlane in zenhub the way they should.