### PR TITLE
Documize upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *output/
 setenv-prod.sh
 apps/artifactory/artifactory-ha/upgrade/backup/*
+# ignore node package artifacts:
+*node_modules/
+*.nvm/

--- a/apps/documize/Dockerfile
+++ b/apps/documize/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 MAINTAINER leo.lou@gov.bc.ca
 
-ARG DVER=3.5.0
+ARG DVER=3.7.0
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN apk update \

--- a/apps/documize/Jenkinsfile
+++ b/apps/documize/Jenkinsfile
@@ -25,13 +25,13 @@ pipeline {
                 sh "cd apps/documize/.pipeline && ./npmw ci && ./npmw run build -- --pr=${CHANGE_ID}"
             }
         }
-        // stage('Deploy (DEV)') {
-        //     agent { label 'deploy' }
-        //     steps {
-        //         echo "Deploying ..."
-        //         sh "cd apps/documize/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=dev"
-        //     }
-        // }
+        stage('Deploy (DEV)') {
+            agent { label 'deploy' }
+            steps {
+                echo "Deploying ..."
+                sh "cd apps/documize/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=dev"
+            }
+        }
         stage('Deploy (TEST)') {
             agent { label 'deploy' }
             when {

--- a/apps/documize/README.md
+++ b/apps/documize/README.md
@@ -11,8 +11,8 @@ Documize is an open source content authoring & automation system that allows tea
 ## Technical Details
 
 ### Application
-- Documize Community Edition v3.3.1
-- Conversion Service version 2.7.0
+- Documize Community Edition v3.7.0
+- Conversion Service version v3.1.0
 - Postgres & Patroni version 10
 - Authentication with RedHat Keycloak 4.8
 

--- a/apps/documize/openshift/conversion-bc.yml
+++ b/apps/documize/openshift/conversion-bc.yml
@@ -66,4 +66,4 @@ parameters:
   displayName: CONVERSION VERSION
   name: CONVERSION_VERSION
   required: true
-  value: 2.7.0
+  value: 3.1.0

--- a/apps/documize/openshift/patroni-deployment.yml
+++ b/apps/documize/openshift/patroni-deployment.yml
@@ -308,9 +308,8 @@ parameters:
   name: PVC_SIZE
   value: 1Gi
 - name: STORAGE_CLASS
-  value: gluster-block
+  value: netapp-block-standard
 - name: IMAGE_REGISTRY
-  #docker-registry.default.svc:5000
   value: docker-registry.default.svc:5000
 - description: The name of the secret
   displayName: Secret Name

--- a/apps/documize/openshift/patroni-deployment.yml
+++ b/apps/documize/openshift/patroni-deployment.yml
@@ -184,6 +184,10 @@ objects:
         securityContext: {}
         serviceAccountName: ${NAME}${SUFFIX}
         terminationGracePeriodSeconds: 0
+        volumes:
+        - name: postgresql
+          persistentVolumeClaim:
+            claimName: postgresql
     updateStrategy:
       type: RollingUpdate
     volumeClaimTemplates:


### PR DESCRIPTION
Updates including:
- Documize Community Edition v3.7.0
- Conversion Service version v3.1.0
- Migrate Gluster to Netapp
- Update probes
- Bring up dev env
- Setup backup patroni instances
