### PR TITLE
resiliency guidelines update

### DIFF
--- a/docs/resiliency-checklist.md
+++ b/docs/resiliency-checklist.md
@@ -44,7 +44,7 @@ Still others let you know the moment an outage starts and can provide extremely 
 ### A Highly Available App
 
 Our platform may have _very_ high availability in general, but our individual _nodes_ do not. This doesn't mean the nodes are unstable or difficult to use - it just means that the way we approach maintenance and infrastructure problems are a little different from the way things work in the legacy application world.
-Did you know that we don't guarantee a single node will be up for more than 24 hours at a time? That's right - our nodes *can* be restarted or changed very often!
+Did you know that we don't guarantee a single node will be up for more than 24 hours at a time? That's right - our nodes *will* be restarted or changed very often!
 This might sound like a big problem with the platform, but it's actually a feature; it means that the platform team can be _extremely_ proactive about keeping the platform's physical infrastructure in great shape. 
 
 Legacy infrastructure is designed to ensure that a specific server will have the highest possible uptime. Clearly, the Openshift Platform works a little differently - instead, we ensure that you will always have _some_ infrastructure to use for your application, but not that the infrastructure will be the same, or that it will remain up forever.

--- a/docs/resiliency-checklist.md
+++ b/docs/resiliency-checklist.md
@@ -17,49 +17,63 @@ description: How to design your application to have as much uptime as possible.
 One of the most amazing benefits of working on the Openshift Platform is that, when your application has been designed with a few key ideas in mind, you can avoid many of the regular outages that are almost unavoidable on legacy infrastructure.
 All that time you used to spend with your application down because you needed to patch a server? Gone.
 If a node needs to go down for patching purposes, a correctly designed application can simply spin up another pod on another node, and your users won't even notice.
+Sounds great, right? But the question is, then: how do you design an application for Openshift if it's so different from applications designed for legacy infrastructure?
 
 ## What does "Correctly Designed" mean?
 
-In order to take advantage of this feature of the cluster, the development team will have to take a design approach that's a little different from legacy design methods.
-In short, this means that your application needs to be **highly available** - it should have multiple pods running simultaneously on different nodes. That way, if one pod goes down (because, for example, it was running on a node that is being evacuated for patching), the others - which will be on different nodes - will continue to chug along without issue and none of your end users will even notice.
-The pod that went down will restart automatically on another node.
+All you need to do is make sure that your application takes advantage of this through some specific design requirements. These are outlined through the concept of a *[12 Factor App](https://12factor.net/)*.
+Of course, this is a technical outline for technical users - here's a bit more of an accessible list of what it means to have a resilient app!
 
-All you need to do is make sure that your application takes advantage of this through some specific design requirements:
+**Note: If you're a technical user looking for some help on how to make a 12-factor app happen, skip to the bottom of this document for examples of applications that run in a resilient manner on our platform already, and feel free to ask those teams for some advice on how they got there!**
 
-### Monitor Your Application!
+### A Monitored App
 
-Monitoring a alerting to issues are key! Regardless of the effort you put into availability and robustness, things happen.
-Your ability to respond to things in a timely manner may be the single most effective tool at your disposal to make sure that your application is up.
+A app that runs without failing most of the time is great, but things happen. Maintenance, failures, network problems, and sneaky little issues in the design or implementation of your app can cause strange behaviours or outages.
+Our platform is extremely highly available, (99.99% available as of mid-2020!) but that doesn't mean you should assume that your application is guaranteed the same - application outages can happen for reasons other than full platform outages.
 
-Monitoring can be performed through health checks - these are scripts which check for a certain outcome on your pod, and can alert you if the expected outcome doesn't occur.
-They can be a great first indicator of problems, and can also cause the pod to restart on its own, which may be enough to fix the issue without requiring your intervention.
+The best way to keep on top of these issues in a proactive manner is to monitor your application and ensure that there are appropriate notifications of issues. There are tons of ways that such a monitoring can be implemented:
+* pod health checks
+* uptime dashboards
+* API health checks
+* storage health checks
+* and more!
 
-There are other options for monitoring as well, but these often vary depending on the specific nature of the project/application in question.
+Many of these notification options provide your team an opportunity to act to prevent an outage before one even starts - finding out, for example, that your storage is almost full _before_ it fills up means that your team can act to deal with the storage issue _before_ it causes an outage or service issue.
+Still others let you know the moment an outage starts and can provide extremely valuable information about the cause of the outage, so your team can begin troubleshooting right away without having to wait for users to inform you of the problem.
 
-### Set up your application to be Highly Available!
+### A Highly Available App
 
-You should have multiple accessible pods running your application at once - **three is the ideal minimum**.
-If any single pod fails, you will still have two other pods in operation while your broken pod recovers.
-In the case of most applications, this is relatively straight-forward and is covered in our [Openshift 101](https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101) course.
-It can be a little more complicated to set up a highly available database, depending on your database of choice.
-If you're looking to use Postgres, check out [Patroni](https://github.com/BCDevOps/platform-services/tree/master/apps/pgsql/patroni) - an open-source, highly-available version of Postgres for use on containerized platforms.
+Our platform may have _very_ high availability in general, but our individual _nodes_ do not. This doesn't mean the nodes are unstable or difficult to use - it just means that the way we approach maintenance and infrastructure problems are a little different from the way things work in the legacy application world.
+Did you know that we don't guarantee a single node will be up for more than 24 hours at a time? That's right - our nodes *can* be restarted or changed very often!
+This might sound like a big problem with the platform, but it's actually a feature; it means that the platform team can be _extremely_ proactive about keeping the platform's physical infrastructure in great shape. 
 
-### Ensure you have regular backups taken of your database(s). 
+Legacy infrastructure is designed to ensure that a specific server will have the highest possible uptime. Clearly, the Openshift Platform works a little differently - instead, we ensure that you will always have _some_ infrastructure to use for your application, but not that the infrastructure will be the same, or that it will remain up forever.
+Now that your team is aware of that, it's simply a matter of architecting your application accordingly. 
 
-If data recovery is necessary, having access to regularly updated off-site data is key to that process.
-You'll also want to script the recovery of those databases regularly. 
-Scripting your data recovery can often mean the difference between bringing your application back up in 5 minutes or 5 hours.
-If you're using Patroni or MongoDB, there is a [backup-container](https://github.com/BCDevOps/backup-container) application developed by and for the community that can help you get started.
+There are plenty of options for ensuring that this change in approach helps your application stay up even longer than it might on legacy infrastructure. 
+After all, your application's ability to jump in an agile manner from one node to the next means that you don't have to endure maintenance outages. 
+If one node goes down for maintenance, your application can simply spin up on another. 
+Or, even better, if your application is _already_ running on multiple nodes, taking down one node has no impact at all!
 
-### Follow implementation-as-code best practices. 
+### An Easily Deployable App
 
-The deployment scripts should be kept up-to-date in your Github repo. 
-If you need to recover by rebuilding from Github, keeping these scripts up-to-date means that you can have your application up and running again nearly at the push of a button, instead of having to fiddle with settings.
+Because all applications on OpenShift should be architected with the expectation that any node can go down at any time, it's imperative that applications be easy and quick to redeploy, requiring - most importantly - **no human interaction in the process**.
+Once the platform is given the command to deploy your software on a new pod, the process between starting up that new pod and having an accessible and useable app should require no human interference whatsoever.
+
+This means that all of your deployment configuration should be automated and kept in source-control to ensure that it is easily accessible, consistent, and up-to-date at all times!
+And that includes any side processes like your monitoring tasks from point 1!
+
+### A Recoverable App
+
+This part isn't so different from legacy applications after all - if you need to recover your app due to data corruption or some other significant failure, it's important that your application be architected to do so quickly and easily.
+Most of this is covered by having an application that is easily deployable, but it's also important that you have the ability to recover anything stateful data and configuration that cannot be held in a repository. In other words, you need to be able to recover your database and application passwords.
 
 ## Community Support
 
 You may note that this document is pretty vague about the "hows" of these principles. This is because it can vary from application to application, and technology stack to technology stack.
-The design needs for a highly available chat application are very different from those of a highly available static website. 
+The design needs for a highly available chat application are very different from those of a highly available static website.
+
+If you're looking for some general guidance on what high availability options exist in Openshift, our [Openshift 101](https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101) course offering covers a number of options, including how to deploy a basic application with high availability.
 
 This is where the community comes in - if you have a highly available application, please feel free to fork this document and add links to examples from your application (along with information about your stack and any explanations you feel might be necessary).
 The more you reach out to help your fellow developer, the stronger a community we will be!
@@ -67,21 +81,33 @@ The more you reach out to help your fellow developer, the stronger a community w
 And it's very important to remember that we in the BC Government are part of a larger, international community of developers working to create better and more resilient applications.
 There are a lot of great resources available on the broader internet that we could never hope to match on our own. A great place to start when looking into these resources would be https://12factor.net/.
 
-### DTS
+### Tools
 
-There are a number of great examples of resilient apps at DTS, with publicly available dashboards providing information about accessibility and uptime:
-- https://uptime.vonx.io/
-- https://tools.uptime.vonx.io/
-- https://dev.uptime.vonx.io/
-- https://test.uptime.vonx.io/
-- https://prod.uptime.vonx.io/
+The Developer Exchange community is full of great developers seeking ways to help the rest of the community - here are some examples of tools that you can use to help build a more resilient application!
 
-We have a variety of alert options to inform us of a problem with our pods or services, and recieve notifications via email and/or RocketChat if there is a problem.
+**[BCDevOps/backup-container](https://github.com/BCDevOps/backup-container)**
+- Features a separate container that can spin up on a schedule in your namespace which connects to your database to perform a backup and/or to perform a test recovery of the most recent backup.
+- Currently works for both Postgres and MongoDB
 
-Here are some additional steps that we take to ensure as much uptime as possible:
-- Setup auto-scaling on pods (services) where ever possible. This way you can set the minimum and maximum number of instances and the number will automatically adjust to load. A minimum of 2 pods is sufficient in the majority of cases if you’re resource constrained, 3 is best. The DTS team has some services that scale to 16 or more instances under load to increase performance.
-- When this is not possible make sure you’re service can restart quickly, that way if it does go down, OpenShift (Kubernetes) can get a new instance back up fast.
-- Setup meaningful health checks and liveliness probes on your applications. This way OpenShift (Kubernetes) can monitor the health and liveliness of your application instances. This allows instances to be taken offline, or even killed and replaced automatically when needed. Without health checks a defunct application instance could remain running or online indefinitely.
-- Use HA instances of services where ever possible. There are HA instances or Postgres (Patroni), MongoDb, and Rabbit Message Queue to name a few. These services typically have 3 pod instances and operate as a cluster.
-- Use monitoring and alerting. Having an HA setup is never enough. If you don’t monitor it, you’ll never know if it’s working. Don’t rely on your customers and users to tell you your system is down. Ultimately you need to be in a position to resolve issues before the users even realize there was an issue, or be able to send out service alerts letting people know you’re aware of an issue and actively dealing with it (before they know about it).
-- Don’t forget your backups. Things like the [BCDevOps/backup-container](https://github.com/BCDevOps/backup-container) make that easy.
+**[BCDevOps/Platform-Services/Patroni](https://github.com/BCDevOps/platform-services/tree/master/apps/pgsql/patroni)**
+- An open-source option for creating a highly available Postgres cluster
+
+### Examples
+
+The following are some fantastic examples of applications that operate on the platform with high resiliency design, as well as a couple of quick summaries of how and why they made the decisions they did.
+If you're aiming to build something similar to an app here, please always feel free to ask the team in question for their advice on how to make your application more resilient as well!
+
+**While these examples all include resilient design, they're not going to be perfect for everyone! Use them as starting points for your making your own decisions about the best architecture for your application, not as gospel for how you are "supposed" to do things!
+And if you have an idea for how any of these projects might improve, offer your idea (and maybe even a helping hand)!**
+
+**[Rocketchat](https://github.com/BCDevOps/platform-services/tree/master/apps/rocketchat)** - Platform Team
+- A highly available implementation of Rocketchat with an autoscaler that can change the total number of pods from a minimum of 3 to a maximum of 5, based on CPU usage.
+- A highly available implementation of a MongoDB stateful set.
+- Pod anti-affinity ensures that no two pods are ever spun up on the same node.
+- MongoDB backups are currently performed using a straightforward cronjob that spins up a pod to connect to the database and perform the backup.
+
+**[Keycloak](https://github.com/bcgov/ocp-sso)** - Platform Team
+- A highly available implementation of Keycloak
+- An example of how to implement Patroni (in the future, this will become an example of highly-available EDB instead)
+
+**If your team has a resilient design of any kind - even if you haven't perfected it - please fork this document and add your repo as an example! Nobody is perfect, and in-progress examples are a great help for teams trying to learn where to start!**

--- a/docs/resiliency-checklist.md
+++ b/docs/resiliency-checklist.md
@@ -79,7 +79,7 @@ This is where the community comes in - if you have a highly available applicatio
 The more you reach out to help your fellow developer, the stronger a community we will be!
 
 And it's very important to remember that we in the BC Government are part of a larger, international community of developers working to create better and more resilient applications.
-There are a lot of great resources available on the broader internet that we could never hope to match on our own. A great place to start when looking into these resources would be https://12factor.net/.
+There are a lot of great resources available on the broader internet that we could never hope to match on our own.
 
 ### Tools
 


### PR DESCRIPTION
rewrote it to remove the focus on specific things that teams should be doing ("you should have at least 3 pods") and made the guidelines more conceptual ("your app should be architected knowing that we do not guarantee the uptime of specific nodes"), while adding examples for specificity.