### PR TITLE
install multiple times without making a mess

### DIFF
--- a/apps/artifactory/artifactory-ha/install.yaml
+++ b/apps/artifactory/artifactory-ha/install.yaml
@@ -78,7 +78,7 @@
       # make secret
     - name: Make the Patroni secrets (processing)
       command: >
-        oc process -f ./templates/patroni-prereq.yaml \
+        oc process -f ./templates/patroni-prereq-1.yaml \
                                              -p NAME=patroni \
                                              -p SUFFIX=-001 \
                                              -p APP_DB_PASSWORD={{ db_password }} \
@@ -90,6 +90,33 @@
       command: >
         oc create -f ./processed/patroni-secret.json
       ignore_errors: yes
+      register: patroni_secret_create
+
+    - name: Make the Patroni prerequisites (processing)
+      command: >
+        oc process -f ./templates/patroni-prereq-2.yaml \
+                                             -p NAME=patroni \
+                                             -p SUFFIX=-001
+      register: patroni_prereq_processed
+    - copy: content="{{ patroni_prereq_processed.stdout }}" dest=./processed/patroni-prereq.json
+    - name: Make the Patroni prerequisites (apply)
+      command: >
+        oc create -f ./processed/patroni-prereq.json
+      ignore_errors: yes
+
+    - name: Get existing password
+      shell: >
+        oc get secret patroni-001 -o json | jq '.data["app-db-password"]' | cut -d'"' -f 2 | base64 -d
+      register: patroni_password
+      when: patroni_secret_create.failed
+
+    - debug:
+        var: patroni_password
+
+    - name: Save password.
+      set_fact:
+        db_password: "{{ patroni_password.stdout }}"
+      when: patroni_secret_create.failed
 
       # deploy patroni stateful set
     - name: Make the Patroni statefulset (processing)
@@ -243,7 +270,11 @@
         force_basic_auth: yes
         status_code: 201
         validate_certs: no
+      register: auth_status
       ignore_errors: yes
+      until: auth_status.status == 201
+      retries: 20
+      delay: 10
 
     - name: Update reader's group
       uri:

--- a/apps/artifactory/artifactory-ha/install.yaml
+++ b/apps/artifactory/artifactory-ha/install.yaml
@@ -88,7 +88,8 @@
     - copy: content="{{ patroni_secret_processed.stdout }}" dest=./processed/patroni-secret.json
     - name: Make the Patroni secrets (apply)
       command: >
-        oc apply -f ./processed/patroni-secret.json
+        oc create -f ./processed/patroni-secret.json
+      ignore_errors: yes
 
       # deploy patroni stateful set
     - name: Make the Patroni statefulset (processing)
@@ -141,11 +142,45 @@
       command: >
         oc apply -f ./processed/route.json
 
+      # make secret
+    - name: Make the admin secret (processing)
+      command: >
+        oc process -f ./templates/artifactory-admin-secret.yaml \
+            ARTIFACTORY_NAME={{ artifactory_instance_name }} \
+            ARTIFACTORY_ADMIN_PASSWORD={{ artifactory_password }}
+      register: app_secret_processed
+    - copy: content="{{ app_secret_processed.stdout }}" dest=./processed/artifactory-admin-secret.json
+    - name: Make the admin secret (apply)
+      command: >
+        oc create -f ./processed/artifactory-admin-secret.json
+      ignore_errors: true
+      register: secret_create
+
+    - name: Get existing password
+      shell: >
+        oc get secret {{ artifactory_instance_name }}-admin -o json | jq '.data.password' | cut -d'"' -f 2 | base64 -d
+      register: password
+      when: secret_create.failed
+
+    - name: Save password.
+      set_fact:
+        artifactory_password: "{{ password.stdout }}"
+      when: secret_create.failed
+
+    - name: Set deployment password
+      set_fact:
+        deployment_password: "password"
+
+    - name: Set deployment password
+      set_fact:
+        deployment_password:  "{{ password.stdout }}"
+      when: secret_create.failed
+
     - name: Check deployment status for artifactory
       uri:
         url: "https://{{ artifactory_url }}/artifactory/api/system/version"
         user: "admin"
-        password: "password"
+        password: "{{ deployment_password }}"
         method: GET
         force_basic_auth: yes
         validate_certs: no
@@ -159,26 +194,15 @@
       uri:
         url: "https://{{ artifactory_url }}/artifactory/api/security/users/authorization/changePassword"
         user: "admin"
-        password: "password"
+        password: "{{ deployment_password }}"
         method: POST
         body_format: json
         headers:
           Content-type: "application/json"
-        body: '{"userName": "admin", "oldPassword": "password", "newPassword1": "{{ artifactory_password }}", "newPassword2": "{{ artifactory_password }}"}'
+        body: '{"userName": "admin", "oldPassword": "{{ deployment_password }}", "newPassword1": "{{ artifactory_password }}", "newPassword2": "{{ artifactory_password }}"}'
         force_basic_auth: yes
         validate_certs: no
-
-      # make secret
-    - name: Make the admin secret (processing)
-      command: >
-        oc process -f ./templates/artifactory-admin-secret.yaml \
-            ARTIFACTORY_NAME={{ artifactory_instance_name }} \
-            ARTIFACTORY_ADMIN_PASSWORD={{ artifactory_password }}
-      register: app_secret_processed
-    - copy: content="{{ app_secret_processed.stdout }}" dest=./processed/artifactory-admin-secret.json
-    - name: Make the admin secret (apply)
-      command: >
-        oc apply -f ./processed/artifactory-admin-secret.json
+      when: deployment_password != artifactory_password
 
     - name: Set artifactory custom URL base
       uri:
@@ -204,6 +228,7 @@
         body: "{{ artifactory_licenses }}"
         force_basic_auth: yes
         validate_certs: no
+        status_code: 200,400
 
     - name: Create authenticated_users group
       uri:
@@ -265,6 +290,7 @@
           Content-type: "application/json"
         body: '{"key" : "{{ item.repo_key }}", "description" : "{{ item.repo_desc }}", "rclass" : "remote", "url" : "{{ item.remote_url }}", "packageType" : "{{ item.pkg_type }}"}'
         force_basic_auth: yes
+        status_code: 200, 400
       ignore_errors: yes
       loop: "{{ repo_list }}"
 

--- a/apps/artifactory/artifactory-ha/templates/patroni-prereq-1.yaml
+++ b/apps/artifactory/artifactory-ha/templates/patroni-prereq-1.yaml
@@ -1,0 +1,68 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: |-
+      Patroni Postgresql database cluster (pre-requisites)
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql pre-requisites
+    openshift.io/long-description: This template deploys patroni pre-requisites for an HA DB (secret, service account, role)
+    tags: postgresql
+  name: patroni-pgsql-pre-requisite
+labels:
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: ${NAME}${SUFFIX}
+      cluster-name: ${NAME}${SUFFIX}
+    annotations:
+      as-copy-of: "template.${NAME}-patroni"
+    name: ${NAME}${SUFFIX}
+  stringData:
+    replication-username: ${PATRONI_REPLICATION_USERNAME}
+    replication-password: ${PATRONI_REPLICATION_PASSWORD}
+    superuser-username: ${PATRONI_SUPERUSER_USERNAME}
+    superuser-password: ${PATRONI_SUPERUSER_PASSWORD}
+    app-db-name: ${APP_DB_NAME}
+    app-db-username: ${APP_DB_USERNAME}
+    app-db-password: ${APP_DB_PASSWORD}
+parameters:
+- description: The name of the application for labelling all artifacts.
+  displayName: Application Name
+  name: NAME
+  value: patroni
+- name: SUFFIX
+- description: Username of the superuser account for initialization.
+  displayName: Superuser Username
+  name: PATRONI_SUPERUSER_USERNAME
+  value: postgres
+#  generate: expression
+#  from: super-[a-zA-Z0-9]{6}
+- description: Password of the superuser account for initialization.
+  displayName: Superuser Passsword
+  name: PATRONI_SUPERUSER_PASSWORD
+  generate: expression
+  from: '[a-zA-Z0-9]{32}'
+- description: Username of the replication account for initialization.
+  displayName: Replication Username
+  name: PATRONI_REPLICATION_USERNAME
+  value: replication
+#  generate: expression
+#  from: rep-[a-zA-Z0-9]{6}
+- description: Password of the replication account for initialization.
+  displayName: Repication Passsword
+  name: PATRONI_REPLICATION_PASSWORD
+  generate: expression
+  from: '[a-zA-Z0-9]{32}'
+- name: APP_DB_USERNAME
+  value: app
+- name: APP_DB_NAME
+  value: app
+- name: APP_DB_PASSWORD
+#  generate: expression
+#  from: '[a-zA-Z0-9]{32}'

--- a/apps/artifactory/artifactory-ha/templates/patroni-prereq-2.yaml
+++ b/apps/artifactory/artifactory-ha/templates/patroni-prereq-2.yaml
@@ -15,23 +15,6 @@ labels:
   app.kubernetes.io/managed-by: template
 objects:
 - apiVersion: v1
-  kind: Secret
-  metadata:
-    labels:
-      app: ${NAME}${SUFFIX}
-      cluster-name: ${NAME}${SUFFIX}
-    annotations:
-      as-copy-of: "template.${NAME}-patroni"
-    name: ${NAME}${SUFFIX}
-  stringData:
-    replication-username: ${PATRONI_REPLICATION_USERNAME}
-    replication-password: ${PATRONI_REPLICATION_PASSWORD}
-    superuser-username: ${PATRONI_SUPERUSER_USERNAME}
-    superuser-password: ${PATRONI_SUPERUSER_PASSWORD}
-    app-db-name: ${APP_DB_NAME}
-    app-db-username: ${APP_DB_USERNAME}
-    app-db-password: ${APP_DB_PASSWORD}
-- apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
@@ -109,32 +92,3 @@ parameters:
   name: NAME
   value: patroni
 - name: SUFFIX
-- description: Username of the superuser account for initialization.
-  displayName: Superuser Username
-  name: PATRONI_SUPERUSER_USERNAME
-  value: postgres
-#  generate: expression
-#  from: super-[a-zA-Z0-9]{6}
-- description: Password of the superuser account for initialization.
-  displayName: Superuser Passsword
-  name: PATRONI_SUPERUSER_PASSWORD
-  generate: expression
-  from: '[a-zA-Z0-9]{32}'
-- description: Username of the replication account for initialization.
-  displayName: Replication Username
-  name: PATRONI_REPLICATION_USERNAME
-  value: replication
-#  generate: expression
-#  from: rep-[a-zA-Z0-9]{6}
-- description: Password of the replication account for initialization.
-  displayName: Repication Passsword
-  name: PATRONI_REPLICATION_PASSWORD
-  generate: expression
-  from: '[a-zA-Z0-9]{32}'
-- name: APP_DB_USERNAME
-  value: app
-- name: APP_DB_NAME
-  value: app
-- name: APP_DB_PASSWORD
-#  generate: expression
-#  from: '[a-zA-Z0-9]{32}'

--- a/apps/artifactory/artifactory-ha/vars.yaml
+++ b/apps/artifactory/artifactory-ha/vars.yaml
@@ -127,3 +127,4 @@ repo_list:
   - { repo_key: 'windward-maven-remote', repo_desc: 'Remote Windward Maven Repository', remote_url: 'http://maven-repository.windward.net/artifactory/libs-release', pkg_type: 'maven' }
   - { repo_key: 'pypi-remote', repo_desc: 'Remote PyPi Repository', remote_url: 'https://pypi.org/', pkg_type: 'pypi' }
   - { repo_key: 'nuget-remote', repo_desc: 'Remote NuGet Repository', remote_url: 'https://nuget.org/', pkg_type: 'nuget' }
+  - { repo_key: 'docker-remote', repo_desc: 'Remote DockerHub Repository', remote_url: 'https://registry-1.docker.io/', pkg_type: 'docker'}


### PR DESCRIPTION
Just added a few additional steps to the installation playbook so that it can be installed over an existing artifactory installation without making a great big mess of things.

Basically, I changed it so instead of using "oc apply" on secrets (which writes over the password, not awesome), I used "oc create" and then registered the response. If the "oc create" fails because the secret already exists, then it collects the existing password and uses that for the rest of the installation script. It does this twice - with the password for the artifactory user in patroni, and for the artifactory admin account password.

I've done some testing, and it looks like the installation works including with a version upgrade from artifactory 7.4.3 to 7.7.3