### PR TITLE
db backup

### DIFF
--- a/apps/artifactory/backup/README.md
+++ b/apps/artifactory/backup/README.md
@@ -1,0 +1,40 @@
+# Backup-container
+
+## Build
+
+Rather than maintaining a custom build configuration, this build will leverage the [backup-container](https://bcdevops/backup-container) templates directly with default values.
+
+```bash
+oc process -f https://raw.githubusercontent.com/BCDevOps/backup-container/master/openshift/templates/backup/backup-build.json | \
+  oc -n devops-artifactory apply -f -
+```
+
+This will build a `latest` tagged image that can be integrated into the pipeline.
+
+## Deploy
+
+Once the postgres service has been deployed, add the helm repository for the published backup-container helm charts.
+
+```bash
+helm repo add bcgov https://bcgov.github.io/helm-charts
+```
+
+Modify deploy-values.yaml and customize for the specific environment
+
+- ensure `image.repository` and `image.tag` are updated per environment/deploy
+- update `env.ENVIRONMENT_NAME.value` for the specific environment
+- verify `persistence.backup.size` and `persistence.verification.size` are appropriately sized.
+
+**Option 1: Deploy direct from helm:**
+
+```bash
+helm install db-backup bcgov/backup-storage -f deploy-values.yaml
+```
+
+**Option 2: Generate manifest using helm, and then apply**
+
+```bash
+helm template db-backup bcgov/backup-storage -f ./openshift/backup/deploy-values.yaml > \
+  ./openshift/backup/db-backup-deploy.yaml
+oc apply -f ./openshift/backup/db-backup-deploy.yaml
+```

--- a/apps/artifactory/backup/backup-build.param
+++ b/apps/artifactory/backup/backup-build.param
@@ -1,0 +1,12 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: backup
+# Template File: https://github.com/BCDevOps/backup-container/blob/master/openshift/templates/backup/backup-build.json
+#=========================================================
+# Commented entries denote template default values
+# NAME=backup-postgres
+# GIT_REPO_URL=https://github.com/BCDevOps/backup-container.git
+# GIT_REF=master
+# SOURCE_CONTEXT_DIR=/docker
+# DOCKER_FILE_PATH=Dockerfile
+# OUTPUT_IMAGE_TAG=latest

--- a/apps/artifactory/backup/deploy-values.yaml
+++ b/apps/artifactory/backup/deploy-values.yaml
@@ -1,0 +1,29 @@
+image:
+  repository: image-registry.openshift-image-registry.svc:5000/devops-artifactory/backup-postgres
+  pullPolicy: Always
+  tag: latest
+
+persistence:
+  backup:
+    size: 5Gi
+    storageClassName: netapp-file-backup
+  verification:
+    size: 5Gi
+
+db:
+  secretName: patroni-001
+  usernameKey: superuser-username
+  passwordKey: superuser-password
+
+env:
+  DATABASE_SERVICE_NAME:
+    value: patroni-master-001
+  ENVIRONMENT_FRIENDLY_NAME:
+    value: "Artifactory DB Backups"
+  ENVIRONMENT_NAME:
+    value: "klab"
+
+backupConfig: |
+  postgres=patroni-master-001:5432/artifactory
+  0 1 * * * default ./backup.sh -s
+  0 4 * * * default ./backup.sh -s -v all


### PR DESCRIPTION
regular running backup container to properly backup the patroni database on which artifactory runs.

see https://github.com/BCDevOps/backup-container for more details.