### PR TITLE
Update platform-experience-general-issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-experience-general-issue.md
+++ b/.github/ISSUE_TEMPLATE/platform-experience-general-issue.md
@@ -10,9 +10,6 @@ assignees: ''
 **Describe the issue**
 A clear and concise description of what you want to happen.
 
-**Which Sprint Priority is this issue related to?**
-The 'Milestone' should clearly list Sprint Priorities - which one is this issue related to?
-
 **Additional context**
 Add any other context, attachments or screenshots
 


### PR DESCRIPTION
@lukegonis  I suggest removing the What Sprint it is related to? question from the template and we assign issues to Sprint Goals during Sprint Planning and this info is not available at the time when the ticket is first open.