### PR TITLE
change the service account's secret name

### DIFF
--- a/apps/artifactory/artifactory-operator/README.md
+++ b/apps/artifactory/artifactory-operator/README.md
@@ -58,7 +58,7 @@ Example ArtifactorySA CR (Custom Resource) exists under `config/crd/bases/tmpl-a
 Create the ArtifactorySA Custom Resource:
 
 ``` bash
- ocas process -f ./config/samples/tmpl-artifactory-sa.yaml -p NAME="test" -p DESCRIPTOR="Description of Service Account" -p REGISTRIES='["docker-remote","redhat-docker-remote"]' | ocas create -f -
+ ocas process -f ./config/samples/tmpl-artifactory-sa.yaml -p NAME="test2" -p DESCRIPTOR="Description of Service Account" -p REGISTRIES='["docker-remote","redhat-docker-remote"]' | ocas create -f -
 ```
 
 #### Service Account Permissions

--- a/apps/artifactory/artifactory-operator/README.md
+++ b/apps/artifactory/artifactory-operator/README.md
@@ -58,7 +58,7 @@ Example ArtifactorySA CR (Custom Resource) exists under `config/crd/bases/tmpl-a
 Create the ArtifactorySA Custom Resource:
 
 ``` bash
- ocas process -f ./config/samples/tmpl-artifactory-sa.yaml -p NAME="test" -p DESCRIPTOR="Description of Service Account" | ocas create -f -
+ ocas process -f ./config/samples/tmpl-artifactory-sa.yaml -p NAME="test" -p DESCRIPTOR="Description of Service Account" -p REGISTRIES='["docker-remote","redhat-docker-remote"]' | ocas create -f -
 ```
 
 #### Service Account Permissions

--- a/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml
+++ b/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml
@@ -11,6 +11,7 @@ objects:
     name: ${NAME}
   spec:
     descriptor: "${DESCRIPTOR}"
+    image_registries: "${REGISTRIES}"
 parameters:
 - description: Name for the ArtifactSvcA custom resource
   displayName: CR Name
@@ -20,3 +21,7 @@ parameters:
   displayName: descriptor
   name: DESCRIPTOR
   value: "My artifact service account"
+- description: Image registries for which to create pull secrets
+  displayName: Image Registries
+  name: REGISTRIES
+  value: "docker-remote"

--- a/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml
+++ b/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml
@@ -24,4 +24,3 @@ parameters:
 - description: Image registries for which to create pull secrets
   displayName: Image Registries
   name: REGISTRIES
-  value: "docker-remote"

--- a/apps/artifactory/artifactory-operator/install/README.md
+++ b/apps/artifactory/artifactory-operator/install/README.md
@@ -28,7 +28,7 @@ ansible-playbook install/clusterAdmin.yml -i install/${Inventory File}
 *START in* `{reporoot}/apps/artifactory/artifactory-operator`
 
 ``` bash
-../oc-push-image.sh -i artifactory-operator -n devops-artifactory -r image-registry.apps.silver.devops.gov.bc.ca -t v1-1.0.0-stable
+../oc-push-image.sh -i artifactory-operator -n devops-artifactory -r image-registry.apps.klab.devops.gov.bc.ca -t v1-1.0.0-stable
 ```
 ### Deploy Operator
 

--- a/apps/artifactory/artifactory-operator/install/README.md
+++ b/apps/artifactory/artifactory-operator/install/README.md
@@ -28,7 +28,7 @@ ansible-playbook install/clusterAdmin.yml -i install/${Inventory File}
 *START in* `{reporoot}/apps/artifactory/artifactory-operator`
 
 ``` bash
-../oc-push-image.sh -i artifactory-operator -n devops-artifactory -r image-registry.apps.klab.devops.gov.bc.ca -t v1-1.0.0-stable
+../oc-push-image.sh -i artifactory-operator -n devops-artifactory -r image-registry.apps.silver.devops.gov.bc.ca -t v1-1.0.0-stable
 ```
 ### Deploy Operator
 

--- a/apps/artifactory/artifactory-operator/playbooks/artserviceacct-destroy.yml
+++ b/apps/artifactory/artifactory-operator/playbooks/artserviceacct-destroy.yml
@@ -42,6 +42,17 @@
           apiVersion: v1
           kind: Secret
           metadata:
-            name: "{{ service_account_name }}"
+            name: "artifacts-{{ meta.name }}"
+            namespace: "{{ meta.namespace }}"
+      when: sa_name is defined
+
+    - name: Delete Pull Secrets for Service Account
+      k8s:
+        state: absent
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "artifacts-pull-{{ meta.name }}"
             namespace: "{{ meta.namespace }}"
       when: sa_name is defined

--- a/apps/artifactory/artifactory-operator/playbooks/artserviceacct-main.yml
+++ b/apps/artifactory/artifactory-operator/playbooks/artserviceacct-main.yml
@@ -20,6 +20,7 @@
       set_fact:
         artifactory_url: "{{ test_url | default('http://artifactory-ha.{{ artifactory_namespace }}.svc.cluster.local:8081') }}"
         service_account_name: "{{ sa_name | default('{{ meta.name }}-{{ project_plate }}-{{ license_plate }}', true) }}"
+        generated_plate: "{{ lookup('password', '/dev/null length=6 chars=ascii_letters') | lower }}"
     
     - import_role:
         name: "artifactory_serviceacct"
@@ -37,12 +38,7 @@
           spec:
             sa_name: "{{ service_account_name }}"
             descriptor: "{{ descriptor }}"
-      when: (sa_name is not defined) or (sa_name|length == 0)
-  
-    # - block:
-    #   - name: "End when SA name not generated"
-    #     debug:
-    #       msg: "Generated SA_NAME."
-    #   - meta: end_play
-    #   when: (sa_name is not defined) or (sa_name|length == 0)
+            current_plate: "{{ generated_plate }}"
+      when: (sa_name is not defined) or (sa_name|length == 0) or (current_plate is not defined) or (current_plate|length == 0)
+
   

--- a/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
+++ b/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
@@ -34,10 +34,6 @@
     generated_password: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
   when: sa_exists.status == 404
 
-- name: Generate plate
-  set_fact:
-    generated_plate: "{{ lookup('password', '/dev/null length=6 chars=ascii_letters') | lower }}"
-
 - name: Create artifactory user
   uri:
     url: "{{ artifactory_url }}/artifactory/api/security/users/{{ service_account_name }}"
@@ -72,6 +68,69 @@
         username: "{{ service_account_name | b64encode }}"
         password: "{{ generated_password | b64encode }}"
   when: created_sa.changed
+
+#- name: Create Pull Secret for Service Account
+#  include_tasks: pull-secret.yaml
+#  with_items:
+#    - "{{ image_registries }}"
+#  loop_control:
+#    loop_var: registry_key
+#  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Set pull secret variables
+  set_fact:
+    pull_auth_decode: "{{ service_account_name }}:{{ generated_password }}"
+    pull_email: "{{ service_account_name }}@{{ meta.namespace }}.local"
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Set encoded pull secret variables
+  set_fact:
+    pull_auth: "{{ pull_auth_decode | b64encode }}"
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Start pull secret json
+  set_fact:
+    pull_json: '{"auths":{'
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Loop pull secret json
+  set_fact:
+    pull_json: '{{ pull_json }}"{{ item }}.artifacts.docker.gov.bc.ca":{"username":"{{ service_account_name }}","password":"{{ generated_password }}","email":"{{ pull_email }}","auth":"{{ pull_auth }}"},'
+  loop: "{{ image_registries }}"
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Remove trailing comma from pull secret json
+  set_fact:
+    pull_json: "{{ pull_json | regex_replace(',$', '') }}"
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: End pull secret json
+  set_fact:
+    pull_json: '{{ pull_json }}}}'
+  when: (created_sa.changed) and (image_registries is defined)
+
+- name: Cast pull secret json
+  set_fact:
+    cast_json: "{{ pull_json | to_json }}"
+
+- name: Create Pull Secret for Service Account
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "artifacts-pull-{{ meta.name }}-{{ generated_plate }}"
+        namespace: "{{ meta.namespace }}"
+        labels:
+          service: artifactory
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ cast_json | b64encode }}"
+
+
+
+
 
 # # Generating an admin token (to replace a service account user), requires adding to a group for access controls.
 # - name: Generate admin token

--- a/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
+++ b/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
@@ -34,6 +34,10 @@
     generated_password: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
   when: sa_exists.status == 404
 
+- name: Generate plate
+  set_fact:
+    generated_plate: "{{ lookup('password', '/dev/null length=6 chars=ascii_letters') | lower }}"
+
 - name: Create artifactory user
   uri:
     url: "{{ artifactory_url }}/artifactory/api/security/users/{{ service_account_name }}"
@@ -59,7 +63,7 @@
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "artifactory-serviceaccount-{{ meta.name }}"
+        name: "artifacts-{{ meta.name }}-{{ generated_plate }}"
         namespace: "{{ meta.namespace }}"
         labels:
           service: artifactory

--- a/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
+++ b/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
@@ -61,6 +61,8 @@
       metadata:
         name: "artifactory-serviceaccount-{{ meta.name }}"
         namespace: "{{ meta.namespace }}"
+        labels:
+          service: artifactory
       type: kubernetes.io/basic-auth
       data:
         username: "{{ service_account_name | b64encode }}"

--- a/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
+++ b/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
@@ -81,37 +81,39 @@
   set_fact:
     pull_auth_decode: "{{ service_account_name }}:{{ generated_password }}"
     pull_email: "{{ service_account_name }}@{{ meta.namespace }}.local"
-  when: (created_sa.changed) and (image_registries is defined)
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: Set encoded pull secret variables
   set_fact:
     pull_auth: "{{ pull_auth_decode | b64encode }}"
-  when: (created_sa.changed) and (image_registries is defined)
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: Start pull secret json
   set_fact:
     pull_json: '{"auths":{'
-  when: (created_sa.changed) and (image_registries is defined)
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: Loop pull secret json
   set_fact:
     pull_json: '{{ pull_json }}"{{ item }}.artifacts.docker.gov.bc.ca":{"username":"{{ service_account_name }}","password":"{{ generated_password }}","email":"{{ pull_email }}","auth":"{{ pull_auth }}"},'
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
   loop: "{{ image_registries }}"
-  when: (created_sa.changed) and (image_registries is defined)
+  ignore_errors: yes
 
 - name: Remove trailing comma from pull secret json
   set_fact:
     pull_json: "{{ pull_json | regex_replace(',$', '') }}"
-  when: (created_sa.changed) and (image_registries is defined)
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: End pull secret json
   set_fact:
     pull_json: '{{ pull_json }}}}'
-  when: (created_sa.changed) and (image_registries is defined)
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: Cast pull secret json
   set_fact:
     cast_json: "{{ pull_json | to_json }}"
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 - name: Create Pull Secret for Service Account
   k8s:
@@ -127,6 +129,7 @@
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: "{{ cast_json | b64encode }}"
+  when: (created_sa.changed) and (image_registries is defined) and (image_registries|length > 0)
 
 
 

--- a/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
+++ b/apps/artifactory/artifactory-operator/roles/artifactory_serviceacct/tasks/main.yml
@@ -59,7 +59,7 @@
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "{{ service_account_name }}"
+        name: "artifactory-serviceaccount-{{ meta.name }}"
         namespace: "{{ meta.namespace }}"
       type: kubernetes.io/basic-auth
       data:


### PR DESCRIPTION
This makes the following updates to the operator:

- secret names now have a license plate
- making an ArtServiceAccount object with a `image_repositories` spec now causes the operator to create a pull secret in addition to the normal secret.