### PR TITLE
RocketChat OAuth SSO update

### DIFF
--- a/docs/RCMigration/rc-oauth-testing-notification.md
+++ b/docs/RCMigration/rc-oauth-testing-notification.md
@@ -1,0 +1,21 @@
+### Test on RC OAuth SSO update:
+This is to track community notifications:
+
+We are going to update RC's OAuth integration with BCGov SSO, from `sso.pathfinder.goc.bc.ca` to `oidc.gov.bc.ca`. And we are looking for some volunteers to help us test out this change in a lower environment (test RC instance).
+
+*If you have access to the following usage of RC and 5 minutes, please login to https://chat-test.pathfinder.gov.bc.ca/ with either IDIR or GitHub account now!*
+- web browser
+- Android RC app
+- iOS RC app
+- desktop RC app
+
+*Testing steps:*
+- drop a message in #general in the test RC instance to let us know you made it!
+- if you are on GitHub account and need someone to invite you, please comment here with your *GitHub account* (we'll invite you :))
+- at noon we will commence with the OAuth change and ask you to *test again logging into the test RC instance* when its complete
+- If you *encounter any issue* while helping us with the test, also let us know here!
+
+Here are the final steps:
+- come back *after 11:30am*
+- test if your current login session is still valid. You can try sending a new message to verify
+- if you have logged out, please try a login again and let us know you made it with the update!

--- a/docs/RCMigration/rc-oauth-update-notification.md
+++ b/docs/RCMigration/rc-oauth-update-notification.md
@@ -1,0 +1,19 @@
+---
+description: BCGov Pathfinder RocketChat OAuth SSO Update
+resourceType: Documentation
+title: BCGov Pathfinder RocketChat OAuth SSO Update
+labels:
+- RocketChat
+- Oauth
+---
+
+## RocketChat OAuth SSO Update
+We are updating RocketChat's Oauth integration with BCGov SSO, from `sso.pathfinder.goc.bc.ca` to `oidc.gov.bc.ca` on December 8th, 2020.
+
+This change have been tested in lower environments, there is `NO expected impact` in your current RC usage or the RC login flow. Authentication behavior will just be how it has been and is consistent between browser/desktop/mobile clients. In the case you do need to login again, please make sure you have refreshed cache and completed quit the browser first.
+
+***Please note the following:***
+- SiteMinder login flow is still not supported on iOS device. You might encounter an 1200 issue when trying to login. If so, please access RC with a web browser and let us know here: https://chat.pathfinder.gov.bc.ca/channel/rocketchat-help?msg=agmDfCJWwRaTxftBA
+- If you experience and issue logging into RocketChat, please contact us at pathfinder@gov.bc.ca.
+
+Thank you!


### PR DESCRIPTION
### Background:
Migrating RC's OAuth config to utilize `oidc.gov.bc.ca` as its sso endpoint for auth flows as `sso.pathfinder.gov.bc.ca` is now deprecated. (this is part of the prep work for RC ocp4 migration)

### Updates:
- this has been tested in a lower environment already and `no impact` was found on community users
- probably no TIB needed?