### PR TITLE
Update dockerhub account for Documize

### DIFF
--- a/apps/documize/Dockerfile
+++ b/apps/documize/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM docker.io/alpine:3.10
 MAINTAINER leo.lou@gov.bc.ca
 
 ARG DVER=3.7.0

--- a/apps/documize/openshift/sa-linked-image-pull-secrets.yml
+++ b/apps/documize/openshift/sa-linked-image-pull-secrets.yml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: documize-dockerhub-account-template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: dockerhub-account-documize
+    namespace: ${NAMESPACE}
+  type: Opaque 
+  stringData: 
+    docker-username: ${DOCKER_USERNAME}
+    docker-password: ${DOCKER_PW}
+    docker-email: unused
+    docker-server: ${DOCKER_SERVER}
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: dockerhub-account-documize
+  metadata:
+    name: builder
+    namespace: ${NAMESPACE}
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: dockerhub-account-documize
+  metadata:
+    name: default
+    namespace: ${NAMESPACE}
+parameters:
+- description: Namespace
+  displayName: namespace
+  name: NAMESPACE
+  required: true
+- description: Docker Username
+  displayName: Docker Username
+  name: DOCKER_USERNAME
+  required: true
+- description: Docker Password
+  displayName: Docker Password
+  name: DOCKER_PW
+  required: true
+- description: Docker Server
+  displayName: Docker Server
+  name: DOCKER_SERVER
+  required: true


### PR DESCRIPTION
## Summary
The Docker account to pull images for Documize needs to be updated to the paid Docker account `bcgovdevops` to solve the rate-limit issue.