### PR TITLE
Update docker secret for documize to use dockerconfigjson

### DIFF
--- a/apps/documize/openshift/sa-linked-image-pull-secrets.yml
+++ b/apps/documize/openshift/sa-linked-image-pull-secrets.yml
@@ -9,12 +9,10 @@ objects:
   metadata:
     name: dockerhub-account-documize
     namespace: ${NAMESPACE}
-  type: Opaque 
-  stringData: 
-    docker-username: ${DOCKER_USERNAME}
-    docker-password: ${DOCKER_PW}
-    docker-email: unused
-    docker-server: ${DOCKER_SERVER}
+  type: kubernetes.io/dockerconfigjson
+  stringData:
+    .dockerconfigjson: >-
+      {"auths":{"${DOCKER_SERVER}":{"username":"${DOCKER_USERNAME}","password":"${DOCKER_PW}","email":"unused","auth":"dGVzdDp0ZXN0Mg=="}}}
 - apiVersion: v1
   kind: ServiceAccount
   imagePullSecrets: 


### PR DESCRIPTION
The original secret type is "opaque". This has been modified to "kubernetes.io/dockerconfigjson" as per documentation in https://github.com/BCDevOps/OpenShift4-Migration/issues/51