### PR TITLE
artifactory - instructions for how users can manage their own service accounts

### DIFF
--- a/apps/artifactory/DEVHUB-README.md
+++ b/apps/artifactory/DEVHUB-README.md
@@ -6,17 +6,55 @@ Artifactory is an Artifact Repository system. It serves two primary purposes:
 1. It provides caching of artifacts that you would normally pull from a public repository on the internet, allowing faster builds and deployments, as well as more robust security surrounding these public objects.
 2. It provides a private space for your team to upload your own artifacts for production purposes.
 
-### Openshift Objects and Related Commands
+## Archeobot
+
+Archeobot is a little bot that lives on each cluster that helps you to "dig" for artifacts!
+For the time being Archeobot is in charge of creating an maintaining your Artifactory Service Accounts.
+Soon, he will also be able to help you create and maintain a private artifact respository in Artifactory, where you will be able to push your own images and other objects!
+
+## Service Accounts
 
 To start, you will require a service account. You will find your service account login information in the `tools` namespace, under secrets, with a name of the format `artifactory-serviceaccount-[account-name]`.
-Every project set is created with one service account to start, with the account name `default` - this means that your secret name will be `artifactory-serviceaccount-default`.
-~~You can also find fuller details about your service account by running the command `oc describe artsvcacct [acct-name]`.~~  
-Users *should* be able to `oc get` and `oc describe` service accounts, but there is an ongoing issue preventing the privilege from propagating to users as expected.
-This issue is currently under investigation and should hopefully be fixed soon!
+Every project set is created with one service account to start, with the account name `default` - this means that your secret name will be `artifacts-default-[plate]` where the plate is random set of 6 alphanumeric characters.
+You can also find fuller details about your service account (including the current plate) by running the command `oc describe ArtifactoryServiceAccount default` or `oc describe artsvcacct default`
 
 For an easy way to get the secret information out via the CLI, try this command:
 
-`oc get secret/artifactory-serviceaccount-default -o json | jq '.data.password' | tr -d "\"" | base64 -d`
+`oc get secret/artifact-default-[plate] -o json | jq '.data.password' | tr -d "\"" | base64 -d`
+
+### Creating New Service Accounts
+
+Those with edit or admin access to their project set can create new Artifactory Service Account objects, and Archeobot will help set up all the various parts necessary to make it work!
+
+You can use the following command to do so:
+
+`oc process -f https://raw.githubusercontent.com/BCDevOps/developer-experience/master/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml -p NAME="accountname" -p DESCRIPTOR="Description of Service Account" -p REGISTRIES='["key1","key2"]' | oc create -f -`
+
+Make sure you change the name and description parameters to suit your needs. 
+The registries parameter is optional - including it causes Archeobot to create a pull secret in addition to the normal secret for every docker registry key you include in the list.
+You will need to ensure that you are including only the registry keys, not the full registry url in this list; for example, `REGISTRIES='["docker-remote","redhat-docker-remote"]`.
+
+This will create an object in your namespace with whatever name you have given it. 
+You can find details about your object like this: `oc describe ArtifactoryServiceAccount [accountname]` or `oc describe artsvcacct [accountname]`
+and your relevant secret will be called `artifacts-[accountname]-[plate]` (as well as `artifacts-pull-[accountname]-[plate]` if you have chosen to include a registry list).
+
+### Deleting Service Accounts
+
+If you want to delete your service account for some reason, you can do so by deleting the ArtifactoryServiceAccount object through the Openshift CLI, like this:
+`oc delete ArtifactoryServiceAccount [accountname]` or `oc delete artsvcacct [accountname]`. 
+
+### I deleted my Artifactory Service Account secret(s)! What do I do now?!
+
+If you have deleted the secret for the default service account that is automatically created alongside your project set, 
+you just delete the ArtifactoryServiceAccount object called `default`, which you will find in your `tools` namespace, like so:
+
+`oc delete ArtifactoryServiceAccount default`
+
+The project provisioning bot will detect that this object has been deleted, and will recreate it automatically. No further action is required from you.
+
+If you have deleted the secret of a service account that you have created, you must delete the relevant ArtifactoryServiceAccount object in the relevant namespace.
+Wait until Archeobot has finished cleaning up all the necessary bits, and then simply create a new object with the same name. 
+This will result in a new account being created with new secret(s) present in the appropriate namespace for you to use!
 
 ## Using Caching Repositories
 

--- a/apps/artifactory/DEVHUB-README.md
+++ b/apps/artifactory/DEVHUB-README.md
@@ -6,10 +6,10 @@ Artifactory is an Artifact Repository system. It serves two primary purposes:
 1. It provides caching of artifacts that you would normally pull from a public repository on the internet, allowing faster builds and deployments, as well as more robust security surrounding these public objects.
 2. It provides a private space for your team to upload your own artifacts for production purposes.
 
-## Archeobot
+## Docent
 
-Archeobot is a little bot that lives on each cluster that helps you to "dig" for artifacts!
-For the time being Archeobot is in charge of creating an maintaining your Artifactory Service Accounts.
+Docent is a little bot that lives on each cluster that helps you access artifacts!
+For the time being Docent is in charge of creating an maintaining your Artifactory Service Accounts.
 Soon, he will also be able to help you create and maintain a private artifact respository in Artifactory, where you will be able to push your own images and other objects!
 
 ## Service Accounts
@@ -24,14 +24,14 @@ For an easy way to get the secret information out via the CLI, try this command:
 
 ### Creating New Service Accounts
 
-Those with edit or admin access to their project set can create new Artifactory Service Account objects, and Archeobot will help set up all the various parts necessary to make it work!
+Those with edit or admin access to their project set can create new Artifactory Service Account objects, and Docent will help set up all the various parts necessary to make it work!
 
 You can use the following command to do so:
 
 `oc process -f https://raw.githubusercontent.com/BCDevOps/developer-experience/master/apps/artifactory/artifactory-operator/config/samples/tmpl-artifactory-sa.yaml -p NAME="accountname" -p DESCRIPTOR="Description of Service Account" -p REGISTRIES='["key1","key2"]' | oc create -f -`
 
 Make sure you change the name and description parameters to suit your needs. 
-The registries parameter is optional - including it causes Archeobot to create a pull secret in addition to the normal secret for every docker registry key you include in the list.
+The registries parameter is optional - including it causes Docent to create a pull secret in addition to the normal secret for every docker registry key you include in the list.
 You will need to ensure that you are including only the registry keys, not the full registry url in this list; for example, `REGISTRIES='["docker-remote","redhat-docker-remote"]`.
 
 This will create an object in your namespace with whatever name you have given it. 
@@ -53,7 +53,7 @@ you just delete the ArtifactoryServiceAccount object called `default`, which you
 The project provisioning bot will detect that this object has been deleted, and will recreate it automatically. No further action is required from you.
 
 If you have deleted the secret of a service account that you have created, you must delete the relevant ArtifactoryServiceAccount object in the relevant namespace.
-Wait until Archeobot has finished cleaning up all the necessary bits, and then simply create a new object with the same name. 
+Wait until Docent has finished cleaning up all the necessary bits, and then simply create a new object with the same name. 
 This will result in a new account being created with new secret(s) present in the appropriate namespace for you to use!
 
 ### I can't find the secret for my default service account!

--- a/apps/artifactory/DEVHUB-README.md
+++ b/apps/artifactory/DEVHUB-README.md
@@ -56,6 +56,16 @@ If you have deleted the secret of a service account that you have created, you m
 Wait until Archeobot has finished cleaning up all the necessary bits, and then simply create a new object with the same name. 
 This will result in a new account being created with new secret(s) present in the appropriate namespace for you to use!
 
+### I can't find the secret for my default service account!
+
+You might have deleted it previously! It's also quite possible that you have one of the older formatted secret names.
+Shortly after OCP4 went live, we made the decision to change the artifactory secret names to something clearer, as they were extremely opaque at release.
+If you are working in a namespace that was created early in the lifespan of the Silver cluster, this might be why you can't find your secret.
+You may find it with the name `default-[namespacename]-[plate]` - see? Not very descriptive!
+
+If this is the case, you can follow the instructions above to delete the `default` ArtifactoryServiceAccount object. 
+It will be automatically recreated for you - this time with the more descriptive name!
+
 ## Using Caching Repositories
 
 The following sections provide some examples for how to pull artifacts through our caching/remote repositories.


### PR DESCRIPTION
This just updates the artifactory documentation to include information on how users can manage their own service accounts (creating them, deleting them, dealing with lost passwords, etc) now that the privilege issue has been cleared up which previously prevented them from doing so on their own.