### PR TITLE
Add proxy deployment manifest

### DIFF
--- a/apps/artifactory/proxy/README.md
+++ b/apps/artifactory/proxy/README.md
@@ -1,0 +1,74 @@
+# TL;DR
+
+This is the deploument manfiest(s) to run the Artifactory proxy needed to allow switchig from
+
+1. `docker-remote.artifacts.developer.gov.bc.ca` -> `artifacts.developer.gov.bc.ca/docker-remote`; and
+2. `redhat-docker-remote.artifacts.developer.gov.bc.ca` -> `artifacts.developer.gov.bc.ca/redhat-docker-remote`.
+
+It will allow the existing URLs to continue to work even though artifactory itself has been switched to the new URL format.
+
+## Deployment
+
+The manifest is not overly generic so it takes one one mandatory parameter, the `DOMAIN_NAME`. This is how it can be adapted to run in a lab environnement or production cluster. For the lab, it is recommended to include the optional REPLICAS parameter set to `1`.
+
+```console
+oc process -f deploy.yaml -p DOMAIN_NAME=apps.klab.devops.gov.bc.ca | \
+oc apply -f -
+```
+
+| NAME          | OPTIONAL | DESCRIPTION | 
+| :-----------: | :------: | :---------- |
+| DOMAIN_NAME   | No       | The base domain name that varies between clusters. |
+| REPLICAS      | Yes      | The number of replica pods to be created. |
+
+Once deployed it will create two routes:
+
+1. https://docker-remote.apps.klab.devops.gov.bc.ca
+2. https://redhat-docker-remote.apps.klab.devops.gov.bc.ca
+
+The any HTTP(S) traffic to these routes will be directed to the proxy where the URL will be adapted for the correct destination. For example, any traffic from docker to `docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest` will be redirected to the URL `artifacts.apps.klab.devops.gov.bc.ca/docker-remote/caddy:latest`
+
+### Docker Example
+
+```console
+➜  docker pull docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+latest: Pulling from caddy
+Digest: sha256:8031d689a8e6f47dcc146121b75946348e8b2e94a183e92cac38a489f55759a2
+Status: Image is up to date for docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+```
+
+## Credential Management
+
+The server used for creating credentials should match whatever server is being used by docker (etc). In the example below, the secret:
+
+```console
+oc create secret docker-registry artifactory-creds \
+--docker-server=docker-remote.apps.klab.devops.gov.bc.ca \
+--docker-username=yyyyyyyyyyy \
+--docker-password=xxxxxxxxxxx \
+--docker-email=unused
+```
+
+Must match the server used but the docker command
+
+```console
+➜  docker pull docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+latest: Pulling from caddy
+Digest: sha256:8031d689a8e6f47dcc146121b75946348e8b2e94a183e92cac38a489f55759a2
+Status: Image is up to date for docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest
+```
+
+and the `image:` used in a deployment manifest:
+
+```yaml
+    spec:
+      containers:
+        - name: my-busybox
+          image: 'docker-remote.apps.klab.devops.gov.bc.ca/busybox:latest'
+```
+
+## TODO
+
+The proxy uses the external URL for artifactory. It maybe more effective to use the internal address (service name) for a more direct connection and to reduce both network latency, traffic, and network path complexity.

--- a/apps/artifactory/proxy/README.md
+++ b/apps/artifactory/proxy/README.md
@@ -28,6 +28,10 @@ Once deployed it will create two routes:
 
 The any HTTP(S) traffic to these routes will be directed to the proxy where the URL will be adapted for the correct destination. For example, any traffic from docker to `docker-remote.apps.klab.devops.gov.bc.ca/caddy:latest` will be redirected to the URL `artifacts.apps.klab.devops.gov.bc.ca/docker-remote/caddy:latest`
 
+**Pro Tip 🤓**
+
+The deployment expects to create routes. If routes already exists comment out route creation and just update existing routes OR (better solution) delete existing routes and let the proxy deployment create its own.
+
 ### Docker Example
 
 ```console
@@ -71,4 +75,6 @@ and the `image:` used in a deployment manifest:
 
 ## TODO
 
-The proxy uses the external URL for artifactory. It maybe more effective to use the internal address (service name) for a more direct connection and to reduce both network latency, traffic, and network path complexity.
+- The proxy uses the external URL for artifactory. It maybe more effective to use the internal address (service name) for a more direct connection and to reduce both network latency, traffic, and network path complexity.
+
+- Add support to read in TLS certificate information as needed

--- a/apps/artifactory/proxy/README.md
+++ b/apps/artifactory/proxy/README.md
@@ -11,6 +11,8 @@ It will allow the existing URLs to continue to work even though artifactory itse
 
 The manifest is not overly generic so it takes one one mandatory parameter, the `DOMAIN_NAME`. This is how it can be adapted to run in a lab environnement or production cluster. For the lab, it is recommended to include the optional REPLICAS parameter set to `1`.
 
+The deployment will pull the `caddy:latest` from artifactory; make sure the credentials are setup before deploying and update the manifests as needed.
+
 ```console
 oc process -f deploy.yaml -p DOMAIN_NAME=apps.klab.devops.gov.bc.ca | \
 oc apply -f -
@@ -30,7 +32,7 @@ The any HTTP(S) traffic to these routes will be directed to the proxy where the 
 
 **Pro Tip 🤓**
 
-The deployment expects to create routes. If routes already exists comment out route creation and just update existing routes OR (better solution) delete existing routes and let the proxy deployment create its own.
+- The deployment expects to create routes. If routes already exists comment out route creation and just update existing routes OR (better solution) delete existing routes and let the proxy deployment create its own.
 
 ### Docker Example
 

--- a/apps/artifactory/proxy/deploy.yaml
+++ b/apps/artifactory/proxy/deploy.yaml
@@ -21,38 +21,38 @@ metadata:
       Deployment for artifactory URL proxy.
   name: proxy
 objects:
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: proxy
-      name: docker-remote
-    spec:
-      host: docker-remote.artifacts.${DOMAIN_NAME}
-      port:
-        targetPort: 2015-tcp
-      tls:
-        termination: edge
-      to:
-        kind: Service
-        name: proxy
-        weight: 100
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: proxy
-      name: redhat-docker-remote
-    spec:
-      host: redhat-docker-remote.artifacts.${DOMAIN_NAME}
-      port:
-        targetPort: 2015-tcp
-      tls:
-        termination: edge
-      to:
-        kind: Service
-        name: proxy
-        weight: 100
+  # - apiVersion: v1
+  #   kind: Route
+  #   metadata:
+  #     labels:
+  #       app: proxy
+  #     name: docker-remote
+  #   spec:
+  #     host: docker-remote.artifacts.${DOMAIN_NAME}
+  #     port:
+  #       targetPort: 2015-tcp
+  #     tls:
+  #       termination: edge
+  #     to:
+  #       kind: Service
+  #       name: proxy
+  #       weight: 100
+  # - apiVersion: v1
+  #   kind: Route
+  #   metadata:
+  #     labels:
+  #       app: proxy
+  #     name: redhat-docker-remote
+  #   spec:
+  #     host: redhat-docker-remote.artifacts.${DOMAIN_NAME}
+  #     port:
+  #       targetPort: 2015-tcp
+  #     tls:
+  #       termination: edge
+  #     to:
+  #       kind: Service
+  #       name: proxy
+  #       weight: 100
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -114,20 +114,22 @@ objects:
           port: 2015
           protocol: TCP
           targetPort: 2015
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: proxy
       name: proxy
     spec:
       strategy:
-        type: Rolling
-      triggers:
-        - type: ConfigChange
+        type: RollingUpdate
+      # triggers:
+      #   - type: ConfigChange
       replicas: ${{REPLICA_COUNT}}
       selector:
-        role: proxy
+        matchLabels:
+          app: proxy
+          role: proxy
       template:
         metadata:
           labels:
@@ -138,7 +140,8 @@ objects:
           containers:
             - name: proxy
               imagePullPolicy: Always
-              image: "artifacts.${DOMAIN_NAME}/caddy:latest"
+              image: "caddy:latest"
+              #image: "artifacts.${DOMAIN_NAME}/caddy:latest"
               env:
                 - name: XDG_DATA_HOME
                   value: /tmp
@@ -158,10 +161,10 @@ objects:
                 - containerPort: 2015
               resources:
                 limits:
-                  cpu: 60m
+                  cpu: 40m
                   memory: 64Mi
                 requests:
-                  cpu: 20m
+                  cpu: 10m
                   memory: 48Mi
               volumeMounts:
                 - name: config-vol
@@ -172,8 +175,8 @@ objects:
               configMap:
                 name: proxy-config
           imagePullSecrets:
-            - name: bcdevops-dockercfg
-  - apiVersion: v1
+            - name: dockerhub-creds
+  - apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
@@ -182,7 +185,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps/v1
-        kind: DeploymentConfig 
+        kind: Deployment 
         name: proxy
       minReplicas: ${{REPLICA_COUNT}}
       maxReplicas: ${{PROXY_MAX_HPA}}
@@ -193,6 +196,21 @@ objects:
           target:
             type: Utilization
             averageUtilization: 80
+  # - apiVersion: networking.k8s.io/v1
+  #   kind: NetworkPolicy
+  #   metadata:
+  #     name: allow-proxy-ingress
+  #   spec:
+  #     ingress:
+  #       - from:
+  #           - namespaceSelector:
+  #               matchLabels:
+  #                 network.openshift.io/policy-group: ingress
+  #     podSelector:
+  #       matchLabels:
+  #         role: proxy
+  #     policyTypes:
+  #       - Ingress
 parameters:
   - name: DOMAIN_NAME
     description:

--- a/apps/artifactory/proxy/deploy.yaml
+++ b/apps/artifactory/proxy/deploy.yaml
@@ -28,7 +28,7 @@ objects:
         app: proxy
       name: docker-remote
     spec:
-      host: docker-remote.${DOMAIN_NAME}
+      host: docker-remote.artifacts.${DOMAIN_NAME}
       port:
         targetPort: 2015-tcp
       tls:
@@ -44,7 +44,7 @@ objects:
         app: proxy
       name: redhat-docker-remote
     spec:
-      host: redhat-docker-remote.${DOMAIN_NAME}
+      host: redhat-docker-remote.artifacts.${DOMAIN_NAME}
       port:
         targetPort: 2015-tcp
       tls:
@@ -62,13 +62,13 @@ objects:
     data:
       Caddyfile: |
         (revpx) {
-          reverse_proxy * https://artifacts.apps.klab.devops.gov.bc.ca {
+          reverse_proxy * https://artifacts.${DOMAIN_NAME} {
             header_up Host {http.reverse_proxy.upstream.hostport}
             header_up X-Forwarded-Port {server_port}
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto {scheme}
-            header_up X-JFrog-Override-Base-Url https://artifacts.apps.klab.devops.gov.bc.ca:443
+            header_up X-JFrog-Override-Base-Url https://artifacts.${DOMAIN_NAME}:443
           }
         }
 
@@ -81,14 +81,14 @@ objects:
           }
         }
 
-        http://docker-remote.apps.klab.devops.gov.bc.ca:2015 {
+        http://docker-remote.artifacts.${DOMAIN_NAME}:2015 {
             uri replace /v2/ /v2/docker-remote/ 1
 
             import revpx "Proxy Commands"
             import logging "Log Config"
         }
 
-        http://redhat-docker-remote.apps.klab.devops.gov.bc.ca:2015 {
+        http://redhat-docker-remote.artifacts.${DOMAIN_NAME}:2015 {
             uri replace /v2/ /v2/redhat-docker-remote/ 1
 
             import revpx "Proxy Commands"
@@ -196,13 +196,15 @@ objects:
 parameters:
   - name: DOMAIN_NAME
     description:
-      xxx
-    displayName: xxx
+      Verry the domain name to deploy to a lab or prod environment. For 
+      example use `developer.gov.bc.ca` for production or
+      `apps.klab.devops.gov.bc.ca` for a lab.
+    displayName: Domain Name
     required: true
   - name: REPLICA_COUNT
     description: The number of PROXY pods to start
     displayName: Replica Count
-    value: "1"
+    value: "3"
   # - name: PROXY_MIN_HPA
   #   description: Min Number of PROXY pods for HPA
   #   displayName: PROXY Min HPA

--- a/apps/artifactory/proxy/deploy.yaml
+++ b/apps/artifactory/proxy/deploy.yaml
@@ -138,7 +138,7 @@ objects:
           containers:
             - name: proxy
               imagePullPolicy: Always
-              image: "${DOMAIN_NAME}/caddy:latest"
+              image: "artifacts.${DOMAIN_NAME}/caddy:latest"
               env:
                 - name: XDG_DATA_HOME
                   value: /tmp
@@ -173,26 +173,26 @@ objects:
                 name: proxy-config
           imagePullSecrets:
             - name: bcdevops-dockercfg
-  # - apiVersion: autoscaling/v1
-  #   kind: HorizontalPodAutoscaler
-  #   metadata:
-  #     labels:
-  #       app: proxy
-  #     name: proxy
-  #   spec:
-  #     scaleTargetRef:
-  #       apiVersion: apps/v1
-  #       kind: DeploymentConfig 
-  #       name: proxy
-  #     minReplicas: ${{ROCKETCHAT_MIN_HPA}}
-  #     maxReplicas: ${{ROCKETCHAT_MAX_HPA}}
-  #     metrics:
-  #     - type: Resource
-  #       resource:
-  #         name: cpu
-  #         target:
-  #           type: Utilization
-  #           averageUtilization: 60
+  - apiVersion: v1
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: proxy
+      name: proxy
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: DeploymentConfig 
+        name: proxy
+      minReplicas: ${{REPLICA_COUNT}}
+      maxReplicas: ${{PROXY_MAX_HPA}}
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
 parameters:
   - name: DOMAIN_NAME
     description:
@@ -205,11 +205,7 @@ parameters:
     description: The number of PROXY pods to start
     displayName: Replica Count
     value: "3"
-  # - name: PROXY_MIN_HPA
-  #   description: Min Number of PROXY pods for HPA
-  #   displayName: PROXY Min HPA
-  #   value: 3
-  # - name: PROXY_MAX_HPA
-  #   description: Max Number of PROXY pods for HPA
-  #   displayName: PROXY Max HPA
-  #   value: 9
+  - name: PROXY_MAX_HPA
+    description: Max Number of PROXY pods for HPA
+    displayName: PROXY Max HPA
+    value: "5"

--- a/apps/artifactory/proxy/deploy.yaml
+++ b/apps/artifactory/proxy/deploy.yaml
@@ -1,0 +1,213 @@
+# Copyright 2021 The Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: |
+      Deployment for artifactory URL proxy.
+  name: proxy
+objects:
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        app: proxy
+      name: docker-remote
+    spec:
+      host: docker-remote.${DOMAIN_NAME}
+      port:
+        targetPort: 2015-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: proxy
+        weight: 100
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        app: proxy
+      name: redhat-docker-remote
+    spec:
+      host: redhat-docker-remote.${DOMAIN_NAME}
+      port:
+        targetPort: 2015-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: proxy
+        weight: 100
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: proxy-config
+      labels:
+        app: proxy
+    data:
+      Caddyfile: |
+        (revpx) {
+          reverse_proxy * https://artifacts.apps.klab.devops.gov.bc.ca {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+            header_up X-Forwarded-Port {server_port}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto {scheme}
+            header_up X-JFrog-Override-Base-Url https://artifacts.apps.klab.devops.gov.bc.ca:443
+          }
+        }
+
+        (logging) {
+          log {
+            # errors stdout
+            output stdout 
+            #format single_field common_log
+            level DEBUG
+          }
+        }
+
+        http://docker-remote.apps.klab.devops.gov.bc.ca:2015 {
+            uri replace /v2/ /v2/docker-remote/ 1
+
+            import revpx "Proxy Commands"
+            import logging "Log Config"
+        }
+
+        http://redhat-docker-remote.apps.klab.devops.gov.bc.ca:2015 {
+            uri replace /v2/ /v2/redhat-docker-remote/ 1
+
+            import revpx "Proxy Commands"
+            import logging "Log Config"
+        }
+
+        :2015 {
+            respond /ehlo 200
+            
+            import logging "Log Config"
+        }
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: proxy
+      name: proxy
+    spec:
+      selector:
+        role: proxy
+      ports:
+        - name: 2015-tcp
+          port: 2015
+          protocol: TCP
+          targetPort: 2015
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: proxy
+      name: proxy
+    spec:
+      strategy:
+        type: Rolling
+      triggers:
+        - type: ConfigChange
+      replicas: ${{REPLICA_COUNT}}
+      selector:
+        role: proxy
+      template:
+        metadata:
+          labels:
+            app: proxy
+            role: proxy
+          name: proxy
+        spec:
+          containers:
+            - name: proxy
+              imagePullPolicy: Always
+              image: "${DOMAIN_NAME}/caddy:latest"
+              env:
+                - name: XDG_DATA_HOME
+                  value: /tmp
+              startupProbe:
+                httpGet:
+                  path: /ehlo
+                  port: 2015
+                  scheme: HTTP
+                failureThreshold: 5
+                periodSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /ehlo
+                  port: 2015
+                timeoutSeconds: 10
+              ports:
+                - containerPort: 2015
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 92Mi
+                requests:
+                  cpu: 30m
+                  memory: 48Mi
+              volumeMounts:
+                - name: config-vol
+                  mountPath: /etc/caddy/Caddyfile
+                  subPath: Caddyfile
+          volumes:
+            - name: config-vol
+              configMap:
+                name: proxy-config
+          imagePullSecrets:
+            - name: bcdevops-dockercfg
+  # - apiVersion: autoscaling/v1
+  #   kind: HorizontalPodAutoscaler
+  #   metadata:
+  #     labels:
+  #       app: proxy
+  #     name: proxy
+  #   spec:
+  #     scaleTargetRef:
+  #       apiVersion: apps/v1
+  #       kind: DeploymentConfig 
+  #       name: proxy
+  #     minReplicas: ${{ROCKETCHAT_MIN_HPA}}
+  #     maxReplicas: ${{ROCKETCHAT_MAX_HPA}}
+  #     metrics:
+  #     - type: Resource
+  #       resource:
+  #         name: cpu
+  #         target:
+  #           type: Utilization
+  #           averageUtilization: 60
+parameters:
+  - name: DOMAIN_NAME
+    description:
+      xxx
+    displayName: xxx
+    required: true
+  - name: REPLICA_COUNT
+    description: The number of PROXY pods to start
+    displayName: Replica Count
+    value: "1"
+  # - name: PROXY_MIN_HPA
+  #   description: Min Number of PROXY pods for HPA
+  #   displayName: PROXY Min HPA
+  #   value: 3
+  # - name: PROXY_MAX_HPA
+  #   description: Max Number of PROXY pods for HPA
+  #   displayName: PROXY Max HPA
+  #   value: 9

--- a/apps/artifactory/proxy/deploy.yaml
+++ b/apps/artifactory/proxy/deploy.yaml
@@ -158,10 +158,10 @@ objects:
                 - containerPort: 2015
               resources:
                 limits:
-                  cpu: 100m
-                  memory: 92Mi
+                  cpu: 60m
+                  memory: 64Mi
                 requests:
-                  cpu: 30m
+                  cpu: 20m
                   memory: 48Mi
               volumeMounts:
                 - name: config-vol
@@ -192,7 +192,7 @@ objects:
           name: cpu
           target:
             type: Utilization
-            averageUtilization: 60
+            averageUtilization: 80
 parameters:
   - name: DOMAIN_NAME
     description:


### PR DESCRIPTION
The deployment manifest in this PR creates a maintenance proxy for the `docker-remote` and `redhat-docker-remote` URLs. They both get redirected to `artifacts...gov.b.ca.ca/docker-remote` and `artifacts...gov.b.ca.ca/redhat-docker-remote` respectively. 